### PR TITLE
change preference popup issue

### DIFF
--- a/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.html
+++ b/src/app/client/src/app/modules/explore-page/components/explore-page/explore-page.component.html
@@ -51,7 +51,7 @@
 
           <!-- Template for displaying sections based on form configuration -->
           <div *ngIf="_currentPageData?.sections && _currentPageData?.isEnabled" aria-label="User Preferences">
-            <div *ngIf="getSelectedTab() === 'home'" (click)="showEdit = !showEdit" class="sb-section-preference"
+            <div *ngIf="getSelectedTab() === 'home'"  class="sb-section-preference"
               tabindex="0">
               <div class="preference">
                 <!-- <p class="header font-weight-bold mb-8">{{resourceService?.frmelmnts?.lbl?.hi}} {{userProfile?.firstName
@@ -90,7 +90,7 @@
                   </span> -->
                 </p>
               </div>
-              <button matTooltip="update your preferences to explore courses and assessments" matTooltipPosition="above"
+              <button matTooltip="update your preferences to explore courses and assessments" matTooltipPosition="above" (click)="showEdit = !showEdit"
                 class="sb-btn sb-btn-primary sb-btn-normal sb-btn-border">{{resourceService?.frmelmnts?.lbl?.changePreferences}}</button>
             </div>
           </div>


### PR DESCRIPTION
# SunbirdEd - Portal
---

UPHRH-5342:- When user clicks any where in the change preference section in the home page. it opens the change preference pop up.The change preference should show only when user click on change preference button.That is fixed

### Please choose applicable option 
#### Example
- [x] Applicable
- [ ] Not applicable

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
